### PR TITLE
 Fix stats admin command crash when statsd-infra-backend is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ StatsD backend for sending metrics to New Relic Infrastructure
 
 ```js
     newrelic: {
-      port: 5001,
+      port: 8001,
       rules: [
         {
           matchExpression: "myapp.*redis.*",

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -1,0 +1,20 @@
+{
+  debug: false,
+  port: 8125,
+  backends: [ "@newrelic/statsd-infra-backend" ],
+  newrelic: {
+    port: 8001,
+    host: "localhost",
+    rules: [
+      {
+        matchExpression: "app1.production.localhost.sample_metric",
+        metricSchema: "{app}.{environment}.{hostname}.{metricName}",
+        eventType: "MyorgApplicationSample",
+        labels: {
+          role: "test",
+          environment: "{environment}"
+        }
+      },
+    ]
+  }
+}

--- a/lib/newrelic-infra.js
+++ b/lib/newrelic-infra.js
@@ -365,7 +365,7 @@ var flushMetrics = function nriFlush(timestamp, rawMetrics) {
 };
 
 var backendStatus = function nriBackendStatus(writeCb) {
-  Object.keys().forEach(function(stat) {
+  Object.keys(nriStats).forEach(function(stat) {
     writeCb(null, 'newrelic', stat, nriStats[stat]);
   });
 };


### PR DESCRIPTION
This PR include the following changes:

- Fix the statsd demon crash when using `stats`command on the admin interface `(default port 8126)` while using the @NewRelic `statsd-infra-backend`

You can replicate this problem by using the command below after loading the `statsd-infra-backend`:
```
14 Jun 10:10:07 - [1] reading config file: config.js
14 Jun 10:10:07 - DEBUG: Loading server: ./servers/udp
14 Jun 10:10:07 - server is up INFO
14 Jun 10:10:07 - DEBUG: Loading backend: @newrelic/statsd-infra-backend
```
```
$ nc 127.0.0.1 8126
stats
uptime: 17
messages.last_msg_seen: 17
messages.bad_lines_seen: 0
$ 
```

From here, `statsd` daemon crash and the traceback was the following:
```
/usr/src/app/node_modules/@newrelic/statsd-infra-backend/lib/newrelic-infra.js:368
  Object.keys().forEach(function(stat) {
         ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at EventEmitter.nriBackendStatus (/usr/src/app/node_modules/@newrelic/statsd-infra-backend/lib/newrelic-infra.js:368:10)
    at emitOne (events.js:95:20)
    at EventEmitter.emit (events.js:182:7)
    at /usr/src/app/stats.js:355:27
    at Socket.<anonymous> (/usr/src/app/lib/mgmt_server.js:13:9)
    at emitOne (events.js:90:13)
    at Socket.emit (events.js:182:7)
    at readableAddChunk (_stream_readable.js:153:18)
    at Socket.Readable.push (_stream_readable.js:111:10)
```

* Update the HTTP port in the documentation to reflect documentation on [statsd-monitoring-integration#example-config](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration#example-config)
* Add missing configuration `exampleConfig.js` file linked into README.md

I have run `npm test` after my changes and everything seems ok:

```
# npm test
npm info it worked if it ends with ok
npm info using npm@3.8.6
npm info using node@v5.12.0
npm info lifecycle @newrelic/statsd-infra-backend@1.0.0~pretest: @newrelic/statsd-infra-backend@1.0.0
npm info lifecycle @newrelic/statsd-infra-backend@1.0.0~test: @newrelic/statsd-infra-backend@1.0.0

> @newrelic/statsd-infra-backend@1.0.0 test /tmp/statsd-infra-backend
> mocha



  New Relic Infrastructure StatsD Backend
    nriInitBackend
      ✓ no matching rules
      ✓ valid matching rules
      ✓ matching rules with invalid metricSchema
      ✓ limit of keys exceeded


  4 passing (37ms)

npm info lifecycle @newrelic/statsd-infra-backend@1.0.0~posttest: @newrelic/statsd-infra-backend@1.0.0
npm info ok
```