### PR TITLE
Fix metrics buffer

### DIFF
--- a/lib/newrelic-infra.js
+++ b/lib/newrelic-infra.js
@@ -130,6 +130,22 @@ var sendPayload = function nriSend(host, port, payload) {
   nriStats.last_flush = Math.round(Date.now() / 1000);
 };
 
+function indexForMetric(metricFields, valueField) {
+  var idx = '';
+  var keys = Object.keys(metricFields);
+  keys.sort();
+  var separator = '';
+  keys.forEach(function (key) {
+    if (valueField === key) {
+      return
+    }
+    idx = idx + separator + key + '=' + metricFields[key];
+    separator = ';'
+  });
+
+  return idx;
+}
+
 var collectMetrics = function nriCollectMetrics(rawMetrics, rules) {
   var gauges = rawMetrics.gauges || {};
   var counters = rawMetrics.counters || {};
@@ -189,24 +205,29 @@ var collectMetrics = function nriCollectMetrics(rawMetrics, rules) {
         var entityType = ruleTemplate(rule.entityType, metricFields);
         var entityId = entityType + ':' + entityName;
 
+        var valueField = metricFields.metricName;
         metricFields[metricFields.metricName] = value;
+        metricFields['event_type'] = eventType;
         delete metricFields.metricName;
 
+        var idx = indexForMetric(metricFields, valueField);
+
         if (data.hasOwnProperty(entityId)) {
-          if (!data[entityId].metrics.hasOwnProperty(eventType)) {
-            data[entityId].metrics[eventType] = [];
+          if (!data[entityId].metrics.hasOwnProperty(idx)) {
+            data[entityId].metrics[idx] = metricFields;
+          } else {
+            data[entityId].metrics[idx][valueField] = value;
           }
-          data[entityId].metrics[eventType].push(metricFields);
         } else {
           data[entityId] = {
             entity: { name: entityName, type: entityType },
             metrics: {}
           };
-          data[entityId].metrics[eventType] = [metricFields];
+          data[entityId].metrics[idx] = metricFields;
         }
 
         Object.keys(rule.labels || {}).forEach(function(label) {
-          data[entityId].metrics[eventType]['label.' + label] = ruleTemplate(rule.labels[label], metricFields);
+          data[entityId].metrics[idx]['label.' + label] = ruleTemplate(rule.labels[label], metricFields);
         });
       } else if (debug) {
         globalLogger.log("It isn't possible to compose an event for key " + metricName + ". It has less elements than metric schema: " + rule.metricSchema);
@@ -273,29 +294,27 @@ var composePayload = function nriPayload(data) {
 
     Object.keys(v1data).forEach(function (entityId) {
       var metrics = v1data[entityId].metrics;
-      Object.keys(metrics).forEach(function (eventType) {
-        eventTypeMetrics = metrics[eventType];
-        eventTypeMetrics.forEach(function (values) {
-          var metricsLength = Object.keys(values).length;
+      Object.keys(metrics).forEach(function (idx) {
+        var values = metrics[idx];
+        var metricsLength = Object.keys(values).length;
 
-          if (metricsLength > metricsLimit) {
-            if (sendLimitErrors) {
-              metricSets.push(
-                {
-                  event_type: "StatsdLimitErrorSample",
-                  numberOfMetrics: metricsLength,
-                  configuredLimit: metricsLimit,
-                }
-              )
-            }
-            if (debug) {
-              globalLogger.log("The event has more than " + metricsLimit + " metrics and can't be processed. Metrics length: " + metricsLength);
-            }
-            nriStats.last_exception = Math.round(Date.now() / 1000);
-          } else {
-            metricSets.push(Object.assign({event_type: eventType}, values));
+        if (metricsLength > metricsLimit) {
+          if (sendLimitErrors) {
+            metricSets.push(
+              {
+                event_type: "StatsdLimitErrorSample",
+                numberOfMetrics: metricsLength,
+                configuredLimit: metricsLimit,
+              }
+            )
           }
-        });
+          if (debug) {
+            globalLogger.log("The event has more than " + metricsLimit + " metrics and can't be processed. Metrics length: " + metricsLength);
+          }
+          nriStats.last_exception = Math.round(Date.now() / 1000);
+        } else {
+          metricSets.push(values);
+        }
       });
     });
     return Object.assign(integration, {metrics: metricSets, inventory: {}, events: []});
@@ -371,6 +390,8 @@ var backendStatus = function nriBackendStatus(writeCb) {
     writeCb(null, 'newrelic', stat, nriStats[stat]);
   });
 };
+
+exports.indexForMetric = indexForMetric;
 
 exports.init = function nriInitBackend(startupTime, config, events, logger) {
   debug = config.debug;

--- a/lib/newrelic-infra.js
+++ b/lib/newrelic-infra.js
@@ -202,8 +202,7 @@ var collectMetrics = function nriCollectMetrics(rawMetrics, rules) {
             entity: { name: entityName, type: entityType },
             metrics: {}
           };
-          data[entityId].metrics[eventType] = [];
-          data[entityId].metrics[eventType].push(metricFields);
+          data[entityId].metrics[eventType] = [metricFields];
         }
 
         Object.keys(rule.labels || {}).forEach(function(label) {

--- a/lib/newrelic-infra.js
+++ b/lib/newrelic-infra.js
@@ -194,15 +194,16 @@ var collectMetrics = function nriCollectMetrics(rawMetrics, rules) {
 
         if (data.hasOwnProperty(entityId)) {
           if (!data[entityId].metrics.hasOwnProperty(eventType)) {
-            data[entityId].metrics[eventType] = {};
+            data[entityId].metrics[eventType] = [];
           }
-          Object.assign(data[entityId].metrics[eventType], metricFields);
+          data[entityId].metrics[eventType].push(metricFields);
         } else {
           data[entityId] = {
             entity: { name: entityName, type: entityType },
             metrics: {}
           };
-          data[entityId].metrics[eventType] = metricFields;
+          data[entityId].metrics[eventType] = [];
+          data[entityId].metrics[eventType].push(metricFields);
         }
 
         Object.keys(rule.labels || {}).forEach(function(label) {
@@ -267,36 +268,38 @@ var composePayload = function nriPayload(data) {
     protocol_version: '1'
   };
 
-  var v1Payload = function(v1data) {
+  var v1Payload = function (v1data) {
     var integration = Object.assign({}, defaultIntegration);
     var metricSets = [];
 
-    Object.keys(v1data).forEach(function(entityId) {
+    Object.keys(v1data).forEach(function (entityId) {
       var metrics = v1data[entityId].metrics;
-      Object.keys(metrics).forEach(function(eventType) {
-        var values = metrics[eventType];
-        var metricsLength = Object.keys(values).length;
+      Object.keys(metrics).forEach(function (eventType) {
+        eventTypeMetrics = metrics[eventType];
+        eventTypeMetrics.forEach(function (values) {
+          var metricsLength = Object.keys(values).length;
 
-        if (metricsLength > metricsLimit) {
-          if (sendLimitErrors) {
-            metricSets.push(
-              {
-                event_type: "StatsdLimitErrorSample",
-                numberOfMetrics: metricsLength,
-                configuredLimit: metricsLimit,
-              }
-            )
+          if (metricsLength > metricsLimit) {
+            if (sendLimitErrors) {
+              metricSets.push(
+                {
+                  event_type: "StatsdLimitErrorSample",
+                  numberOfMetrics: metricsLength,
+                  configuredLimit: metricsLimit,
+                }
+              )
+            }
+            if (debug) {
+              globalLogger.log("The event has more than " + metricsLimit + " metrics and can't be processed. Metrics length: " + metricsLength);
+            }
+            nriStats.last_exception = Math.round(Date.now() / 1000);
+          } else {
+            metricSets.push(Object.assign({event_type: eventType}, values));
           }
-          if (debug) {
-            globalLogger.log("The event has more than " + metricsLimit + " metrics and can't be processed. Metrics length: " + metricsLength);
-          }
-          nriStats.last_exception = Math.round(Date.now() / 1000);
-        } else {
-          metricSets.push(Object.assign({ event_type: eventType }, values));
-        }
+        });
       });
     });
-    return Object.assign(integration, { metrics: metricSets, inventory: {}, events: [] });
+    return Object.assign(integration, {metrics: metricSets, inventory: {}, events: []});
   };
 
   var v2Payload = function(v2data) {

--- a/test/test.js
+++ b/test/test.js
@@ -160,7 +160,8 @@ describe('New Relic Infrastructure StatsD Backend', function () {
       const metrics = {
         gauges: {
           'nomad.client.allocs.cpu.total_percent.job-a.task-group-a.xxx-yyy.task-a.ip-foo-bar': 0.58028,
-          'nomad.client.allocs.cpu.total_percent.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.026463
+          'nomad.client.allocs.cpu.total_percent.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.026463,
+          'nomad.client.allocs.cpu.user.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.01
         }
       };
       const expected = defaultIntegration;
@@ -188,6 +189,7 @@ describe('New Relic Infrastructure StatsD Backend', function () {
           taskGroupName: "task-group-b",
           allocationID: "yyy-zzz",
           taskName: "task-b",
+          user: 0.1,
           total_percent: 0.026463
         }
       ];

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,32 @@ const nri = require('../lib/newrelic-infra.js');
 const util = require('util');
 const nock = require('nock');
 
+describe('Unit testing indexForMetric', function () {
+
+  it('indexes a metric by all the attributes except the value field', function(done){
+    let fields = {
+      "app": "foo",
+      "client": "bar",
+      "foo": 0.13
+    };
+
+    assert.equal(nri.indexForMetric(fields, "foo"), "app=foo;client=bar");
+    done();
+  });
+
+  it('indexes by sorting alphabetically', function(done){
+    let fields = {
+      "client": "bar",
+      "app": "foo",
+      "foo": 0.13
+    };
+
+    assert.equal(nri.indexForMetric(fields, "foo"), "app=foo;client=bar");
+    done();
+  });
+
+});
+
 describe('New Relic Infrastructure StatsD Backend', function () {
   before(function () {
     nock.disableNetConnect();
@@ -85,30 +111,14 @@ describe('New Relic Infrastructure StatsD Backend', function () {
       const expected = defaultIntegration;
       expected.metrics = [
         {
-          "app": "myapp",
           "event_type": "RedisSample",
+          "app": "myapp",
+          "service": "redis",
           "my_counter": 10,
-          "service": "redis"
-        }, {
-          "app": "myapp",
-          "event_type": "RedisSample",
           "my_counterPerSecond": 1,
-          "service": "redis"
-        }, {
-          "app": "myapp",
-          "event_type": "RedisSample",
-          "my_timer.sum": 10,
-          "service": "redis"
-        }, {
-          "app": "myapp",
-          "event_type": "RedisSample",
-          "my_timer.mean": 10,
-          "service": "redis"
-        }, {
-          "app": "myapp",
-          "event_type": "RedisSample",
           "my_gauge": 1,
-          "service": "redis"
+          "my_timer.mean": 10,
+          "my_timer.sum": 10,
         }
       ];
 
@@ -159,9 +169,9 @@ describe('New Relic Infrastructure StatsD Backend', function () {
       }];
       const metrics = {
         gauges: {
-          'nomad.client.allocs.cpu.total_percent.job-a.task-group-a.xxx-yyy.task-a.ip-foo-bar': 0.58028,
-          'nomad.client.allocs.cpu.total_percent.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.026463,
-          'nomad.client.allocs.cpu.user.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.01
+           'nomad.client.allocs.cpu.total_percent.job-a.task-group-a.xxx-yyy.task-a.ip-foo-bar': 0.58028
+          ,'nomad.client.allocs.cpu.total_percent.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.026463
+          ,'nomad.client.allocs.cpu.foo_bar_baz_q.job-b.task-group-b.yyy-zzz.task-b.ip-foo-bar': 0.01
         }
       };
       const expected = defaultIntegration;
@@ -189,7 +199,7 @@ describe('New Relic Infrastructure StatsD Backend', function () {
           taskGroupName: "task-group-b",
           allocationID: "yyy-zzz",
           taskName: "task-b",
-          user: 0.1,
+          foo_bar_baz_q: 0.01,
           total_percent: 0.026463
         }
       ];
@@ -232,23 +242,7 @@ describe('New Relic Infrastructure StatsD Backend', function () {
       expected.metrics = [
         {
           event_type: 'StatsdLimitErrorSample',
-          numberOfMetrics: 3,
-          configuredLimit: metricsLimit
-        },{
-          event_type: 'StatsdLimitErrorSample',
-          numberOfMetrics: 3,
-          configuredLimit: metricsLimit
-        },{
-          event_type: 'StatsdLimitErrorSample',
-          numberOfMetrics: 3,
-          configuredLimit: metricsLimit
-        },{
-          event_type: 'StatsdLimitErrorSample',
-          numberOfMetrics: 3,
-          configuredLimit: metricsLimit
-        },{
-          event_type: 'StatsdLimitErrorSample',
-          numberOfMetrics: 3,
+          numberOfMetrics: 8,
           configuredLimit: metricsLimit
         }];
       const httpserver = nock('http://localhost:9070')


### PR DESCRIPTION
Fix metrics overlapping buffer by appending events.

Issue link: https://github.com/newrelic/statsd-infra-backend/issues/6

Issue definition: 
> When several metrics share event-type and rule, then metric **keys** are overridden and only _last metric value for that key_ is published.

Now metrics are grouped for the same entity when if all the attributes (names & values) are equal.